### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
 jobs:
   laravel-tests:
 


### PR DESCRIPTION
Potential fix for [https://github.com/NoxGamingQC/Website/security/code-scanning/1](https://github.com/NoxGamingQC/Website/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow (either at the root level to apply to all jobs, or inside the specific job block if different jobs need different levels of permissions). Since this workflow does not seem to require any write permissions, the minimal and recommended block is:

```yaml
permissions:
  contents: read
```

This should be placed near the top, after the `name:` and `on:` keys, and before `jobs:`. No other imports nor code changes are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
